### PR TITLE
Center all pages on screen

### DIFF
--- a/search.js
+++ b/search.js
@@ -98,17 +98,24 @@
       .muted { color: #6b7280; font-size: 0.9rem; }
       mark { background: #fff3cd; padding: 0 2px; border-radius: 2px; }
 
-      /* Non-home overrides: place search at top-right within header */
+      /* Non-home overrides: place search at top-right; results float so layout is not affected */
       .is-non-home header { position: relative; }
       .is-non-home #search-container {
         position: absolute; top: 0.75rem; right: 0.75rem; margin: 0; text-align: right;
       }
       .is-non-home #search-input { width: 220px; max-width: 60vw; }
-      .is-non-home #search-results { margin-top: 1rem; }
+      /* Make results a floating panel to avoid shifting page content (e.g., flex-centered bodies) */
+      .is-non-home #search-results {
+        position: fixed; top: 3.25rem; right: 0.75rem; margin: 0; width: 360px; max-width: 90vw;
+        max-height: 60vh; overflow: auto; background: #fff; border: 1px solid #e5e7eb; border-radius: 8px;
+        padding: 0.5rem; box-shadow: 0 10px 24px rgba(0,0,0,0.1); z-index: 50;
+      }
+      .is-non-home #search-results:empty { display: none; }
       .is-non-home #search-status { display: inline-block; margin-left: 0.75rem; vertical-align: middle; }
 
       @media (max-width: 640px) {
         .is-non-home #search-input { width: 55vw; }
+        .is-non-home #search-results { left: 0.5rem; right: 0.5rem; width: auto; max-height: 50vh; }
       }
     `;
     document.head.appendChild(style);


### PR DESCRIPTION
Make search results a fixed-position floating panel to prevent content from being pushed aside.

Previously, the injected `#search-results` element was a flex item on pages with a `display: flex` body, which caused the main page content to be pushed to the side. Setting its position to `fixed` removes it from the document flow, allowing the page's primary content to center correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e36d6bf-d829-461d-b209-22ee89b8d5d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e36d6bf-d829-461d-b209-22ee89b8d5d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

