### PR TITLE
Add youtube thumbnails to module 7 page

### DIFF
--- a/Task 2 Modules/module7.html
+++ b/Task 2 Modules/module7.html
@@ -75,6 +75,31 @@
     margin-left: auto;
     margin-right: auto;
   }
+  .video-thumbs {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin: 0.5rem 0 1rem;
+  }
+  .video-thumbs a {
+    display: inline-block;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+    background: #fff;
+    transition: transform 0.2s, box-shadow 0.2s;
+  }
+  .video-thumbs a:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 3px 8px rgba(0,0,0,0.12);
+  }
+  .video-thumbs img {
+    display: block;
+    width: 200px;
+    height: auto;
+    margin: 0;
+  }
 </style>
 </head>
 <body>
@@ -111,10 +136,46 @@
 
     <h3>Maintaining and Replacing Components</h3>
     <ul>
-      <li><strong>Circular Saw - Blade Replacement:</strong> Disconnect power. Use a spanner or locking button to hold the blade. Loosen the retaining bolt, remove old blade, fit new blade with correct rotation direction, tighten and test before use.</li>
-      <li><strong>Power Planer - Blade Replacement:</strong> Disconnect power. Loosen blade housing screws or release lever. Remove old blades and fit new ones evenly. Secure tightly and ensure balance across the drum.</li>
-      <li><strong>Router - Bit Replacement:</strong> Disconnect power. Use two spanners or a locking button to loosen the collet. Remove old bit, insert new bit to correct depth, and tighten securely. Double-check seating.</li>
-      <li><strong>Angle Grinder - Disc Replacement:</strong> Disconnect power. Lock the disc with a spanner, loosen the nut. Replace disc with correct type. Check rotation direction and tighten nut securely.</li>
+      <li><strong>Circular Saw - Blade Replacement:</strong> Disconnect power. Use a spanner or locking button to hold the blade. Loosen the retaining bolt, remove old blade, fit new blade with correct rotation direction, tighten and test before use.
+        <div class="video-thumbs">
+          <a href="https://www.youtube.com/watch?v=DqfwuDq3B84" target="_blank" rel="noopener noreferrer">
+            <img src="https://img.youtube.com/vi/DqfwuDq3B84/hqdefault.jpg" alt="Circular saw: blade replacement video 1">
+          </a>
+          <a href="https://www.youtube.com/watch?v=xkk8oSZXrmc" target="_blank" rel="noopener noreferrer">
+            <img src="https://img.youtube.com/vi/xkk8oSZXrmc/hqdefault.jpg" alt="Circular saw: blade replacement video 2">
+          </a>
+        </div>
+      </li>
+      <li><strong>Power Planer - Blade Replacement:</strong> Disconnect power. Loosen blade housing screws or release lever. Remove old blades and fit new ones evenly. Secure tightly and ensure balance across the drum.
+        <div class="video-thumbs">
+          <a href="https://www.youtube.com/watch?v=O-xiNy5xAbU" target="_blank" rel="noopener noreferrer">
+            <img src="https://img.youtube.com/vi/O-xiNy5xAbU/hqdefault.jpg" alt="Power planer: blade replacement video 1">
+          </a>
+          <a href="https://www.youtube.com/watch?v=NYdynySJlow" target="_blank" rel="noopener noreferrer">
+            <img src="https://img.youtube.com/vi/NYdynySJlow/hqdefault.jpg" alt="Power planer: blade replacement video 2">
+          </a>
+        </div>
+      </li>
+      <li><strong>Router - Bit Replacement:</strong> Disconnect power. Use two spanners or a locking button to loosen the collet. Remove old bit, insert new bit to correct depth, and tighten securely. Double-check seating.
+        <div class="video-thumbs">
+          <a href="https://www.youtube.com/watch?v=ziZ0JT3wDHI" target="_blank" rel="noopener noreferrer">
+            <img src="https://img.youtube.com/vi/ziZ0JT3wDHI/hqdefault.jpg" alt="Router: bit replacement video 1">
+          </a>
+          <a href="https://www.youtube.com/watch?v=FprtJbDgO4k" target="_blank" rel="noopener noreferrer">
+            <img src="https://img.youtube.com/vi/FprtJbDgO4k/hqdefault.jpg" alt="Router: bit replacement video 2">
+          </a>
+        </div>
+      </li>
+      <li><strong>Angle Grinder - Disc Replacement:</strong> Disconnect power. Lock the disc with a spanner, loosen the nut. Replace disc with correct type. Check rotation direction and tighten nut securely.
+        <div class="video-thumbs">
+          <a href="https://www.youtube.com/watch?v=fHsxdi9E4PM" target="_blank" rel="noopener noreferrer">
+            <img src="https://img.youtube.com/vi/fHsxdi9E4PM/hqdefault.jpg" alt="Angle grinder: disc replacement video 1">
+          </a>
+          <a href="https://www.youtube.com/watch?v=Kt28KphCaZw" target="_blank" rel="noopener noreferrer">
+            <img src="https://img.youtube.com/vi/Kt28KphCaZw/hqdefault.jpg" alt="Angle grinder: disc replacement video 2">
+          </a>
+        </div>
+      </li>
     </ul>
 
     <h3>Sharpening Edge Tools (Hand Planes & Chisels)</h3>


### PR DESCRIPTION
Add YouTube video thumbnails for power tool maintenance to `module7.html` to provide supplementary visual material.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ee16572-36b3-4b13-a97d-dbd778607206">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ee16572-36b3-4b13-a97d-dbd778607206">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

