### PR TITLE
Add JSA activity sheet link to module 4

### DIFF
--- a/Task 2 Modules/module4.html
+++ b/Task 2 Modules/module4.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
@@ -91,7 +91,7 @@
     <p>Before starting any practical task, students must conduct proper planning to ensure the site is safe, compliant, and ready for efficient work.</p>
     <ul>
       <li><strong>Inspect the work area</strong> - Look for trip hazards, uneven surfaces, poor lighting, or clutter.</li>
-      <li><strong>Complete a Job Safety Analysis (JSA)</strong> - Identify potential hazards and outline controls.</li>
+      <li><strong>Complete a Job Safety Analysis (JSA)</strong> - Identify potential hazards and outline controls. <a href="../Task%206%20Modules/module2.html" target="_blank" style="color: #dc2626; font-weight: 600; text-decoration: underline;">📋 View JSA Activity Sheet Examples →</a></li>
       <li><strong>Read and follow the Safe Operating Procedure (SOP)</strong> - For every tool or machine being used.</li>
       <li><strong>Review equipment manuals</strong> - Understand how to operate, adjust, and maintain tools.</li>
       <li><strong>Follow signage</strong> - Electrical hazard warnings, or restricted areas.</li>


### PR DESCRIPTION
Add a link to the JSA activity sheet in `module4.html` to provide direct access to examples from the safety module.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b85376f-db57-4405-93b6-0ca512098a51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b85376f-db57-4405-93b6-0ca512098a51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

