### PR TITLE
Remove duplicate intro hero image

### DIFF
--- a/index.html
+++ b/index.html
@@ -531,11 +531,11 @@
   </header>
 <section class="course-family-intro course-family-intro--vet" aria-labelledby="course-family-intro-title">
   <div class="course-family-intro__inner">
-    <header class="course-family-intro__heading">
+    <div class="course-family-intro__heading">
       <p class="course-family-intro__eyebrow">VET Construction</p>
       <h2 id="course-family-intro-title">Welcome to the Stage 6 Construction Hub</h2>
       <p class="course-family-intro__lede">This is the central access point for supplementary learning materials linked to the seven main Construction assessment tasks.</p>
-    </header>
+    </div>
     <div class="course-family-intro__routine">
       <div class="course-family-intro__routine-heading">
         <p class="course-family-intro__eyebrow">How the course works</p>


### PR DESCRIPTION
Removes the unintended second hero treatment from the course introduction by changing the nested semantic header to a neutral content container. The standard main hero and all introduction text remain unchanged.